### PR TITLE
[#3]feat: DB 및 엔티티 확정

### DIFF
--- a/src/main/java/com/kangsol/extension_policy/config/DataInitializer.java
+++ b/src/main/java/com/kangsol/extension_policy/config/DataInitializer.java
@@ -1,0 +1,4 @@
+package com.kangsol.extension_policy.config;
+
+public class DataInitializer {
+}

--- a/src/main/java/com/kangsol/extension_policy/config/JpaAuditingConfig.java
+++ b/src/main/java/com/kangsol/extension_policy/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.kangsol.extension_policy.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/kangsol/extension_policy/entity/BaseEntity.java
+++ b/src/main/java/com/kangsol/extension_policy/entity/BaseEntity.java
@@ -1,4 +1,26 @@
 package com.kangsol.extension_policy.entity;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
 public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
 }

--- a/src/main/java/com/kangsol/extension_policy/entity/Extension.java
+++ b/src/main/java/com/kangsol/extension_policy/entity/Extension.java
@@ -1,4 +1,0 @@
-package com.kangsol.extension_policy.entity;
-
-public class Extension {
-}

--- a/src/main/java/com/kangsol/extension_policy/entity/ExtensionPolicy.java
+++ b/src/main/java/com/kangsol/extension_policy/entity/ExtensionPolicy.java
@@ -1,0 +1,51 @@
+package com.kangsol.extension_policy.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "extension_policy")
+@Getter
+public class ExtensionPolicy {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 확장자
+    @Column(name = "ext", nullable = false, unique = true, length = 20)
+    private String ext;
+
+    // 확장자 타입(고정/커스텀)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private ExtensionType type;
+
+    // 차단 여부 (true:차단 / false:차단해제)
+    @Column(name = "blocked", nullable = false)
+    private boolean blocked;
+
+    protected ExtensionPolicy(){}
+
+    // 외부 생성 방지
+    private ExtensionPolicy(String ext, ExtensionType type, boolean blocked){
+        this.ext = ext;
+        this.type = type;
+        this.blocked = blocked;
+    }
+
+    // 고정 확장자 초기 시딩용
+    public static ExtensionPolicy fixed(String ext){
+        return new ExtensionPolicy(ext, ExtensionType.FIXED, false);
+    }
+
+    // 커스텀 확장자 생성용
+    public static ExtensionPolicy custom(String ext){
+        return new ExtensionPolicy(ext, ExtensionType.CUSTOM, true);
+    }
+
+    // 차단 상태 변경
+    public void changeBlocked(boolean blocked){
+        this.blocked = blocked;
+    }
+}

--- a/src/main/java/com/kangsol/extension_policy/entity/ExtensionType.java
+++ b/src/main/java/com/kangsol/extension_policy/entity/ExtensionType.java
@@ -1,0 +1,6 @@
+package com.kangsol.extension_policy.entity;
+
+public enum ExtensionType {
+    FIXED,
+    CUSTOM
+}


### PR DESCRIPTION
## 작업 내용
- 확장자 정책 테이블 및 엔티티 구조 확정
- 고정/커스텀 확장자 타입 분리
- 차단 여부(blocked) 정책 반영

-close: #3 